### PR TITLE
Initialize Flask host tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-"# NINE" 
+# NINE
+
+This repository contains a sample Flask application located in `host_tracker/`.
+The application exposes a small API for updating progress on hosts and includes
+scheduled tasks that refresh host profile information.
+
+## Setup
+
+1. Install Python dependencies:
+   ```bash
+   pip install Flask Flask-SQLAlchemy APScheduler
+   ```
+2. Run the server:
+   ```bash
+   python host_tracker/app.py
+   ```
+
+The server will start on `http://127.0.0.1:5000`. A background scheduler will
+update host profiles every minute.
+
+## Usage
+
+Visit `http://127.0.0.1:5000/progress_form` to update progress for existing
+hosts. You can query current host data via `GET /hosts` and update progress via
+`POST /hosts/<id>/progress`.

--- a/host_tracker/app.py
+++ b/host_tracker/app.py
@@ -1,0 +1,67 @@
+from datetime import datetime
+from flask import Flask, request, jsonify, render_template
+from apscheduler.schedulers.background import BackgroundScheduler
+
+from .models import db, Host
+
+app = Flask(__name__)
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///hosts.db'
+app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+
+db.init_app(app)
+
+
+@app.before_first_request
+def create_tables():
+    db.create_all()
+
+
+def update_host_profiles():
+    """Scheduled task to refresh host profile timestamps."""
+    with app.app_context():
+        hosts = Host.query.all()
+        for host in hosts:
+            host.profile_last_updated = datetime.utcnow()
+        db.session.commit()
+
+
+scheduler = BackgroundScheduler()
+scheduler.add_job(update_host_profiles, 'interval', minutes=1)
+scheduler.start()
+
+
+@app.route('/hosts/<int:id>/progress', methods=['POST'])
+def update_progress(id):
+    """Update host progress and profile timestamp."""
+    host = Host.query.get_or_404(id)
+    data = request.get_json() or request.form
+    if 'progress' not in data:
+        return jsonify({'error': 'progress value required'}), 400
+    host.progress = int(data['progress'])
+    host.profile_last_updated = datetime.utcnow()
+    db.session.commit()
+    return jsonify({'status': 'updated', 'id': host.id, 'progress': host.progress})
+
+
+@app.route('/hosts', methods=['GET'])
+def list_hosts():
+    hosts = Host.query.all()
+    result = []
+    for h in hosts:
+        result.append({
+            'id': h.id,
+            'name': h.name,
+            'progress': h.progress,
+            'profile_last_updated': h.profile_last_updated.isoformat() if h.profile_last_updated else None
+        })
+    return jsonify(result)
+
+
+@app.route('/progress_form')
+def progress_form():
+    hosts = Host.query.all()
+    return render_template('progress_form.html', hosts=hosts)
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/host_tracker/models.py
+++ b/host_tracker/models.py
@@ -1,0 +1,13 @@
+from flask_sqlalchemy import SQLAlchemy
+from datetime import datetime
+
+db = SQLAlchemy()
+
+class Host(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(128), nullable=False)
+    progress = db.Column(db.Integer, default=0)
+    profile_last_updated = db.Column(db.DateTime, default=datetime.utcnow)
+
+    def __repr__(self):
+        return f"<Host {self.name}>"

--- a/host_tracker/templates/progress_form.html
+++ b/host_tracker/templates/progress_form.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html>
+<head>
+    <title>Update Host Progress</title>
+</head>
+<body>
+    <h1>Update Host Progress</h1>
+    {% for host in hosts %}
+    <form action="{{ url_for('update_progress', id=host.id) }}" method="post">
+        <h3>{{ host.name }}</h3>
+        <input type="number" name="progress" value="{{ host.progress }}" min="0">
+        <button type="submit">Update</button>
+    </form>
+    {% endfor %}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- initialize minimal Flask project under `host_tracker/`
- define `Host` model with SQLAlchemy
- implement API routes and scheduled profile updates
- add a simple progress form template
- document setup and usage instructions

## Testing
- `python -m py_compile host_tracker/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68431c8ec2e48330959aa6c893ceb13c